### PR TITLE
Improve displaying of objects and arrays

### DIFF
--- a/lib/types/json-array.vue
+++ b/lib/types/json-array.vue
@@ -51,7 +51,7 @@ export default {
       elements.push(h('span', {
         class: {
           'jv-toggle': true,
-          'open': !!this.expand, 
+          'open': !!this.expand,
         },
         on: {
           click: this.toggle
@@ -62,20 +62,18 @@ export default {
     elements.push(h('span', {
       class: {
         'jv-item': true,
-        'jv-array': true, 
+        'jv-array': true,
       },
       domProps: {
         innerHTML: '['
       }
     }))
 
-    for (let key in this.ordered) {
-      let value = this.ordered[key]
-
+    this.ordered.forEach((value, key) => {
       elements.push(h(JsonBox, {
         key,
         style: {
-          display: !this.expand ? 'none' : undefined
+          display: this.expand ? undefined : 'none'
         },
         props: {
           sort: this.sort,
@@ -84,15 +82,15 @@ export default {
           value,
         }
       }))
-    }
+    })
 
-    if (!this.expand) {
+    if (!this.expand && this.jsonValue.length) {
       elements.push(h('span', {
         style: {
-          display: this.expand ? 'none' : undefined
+          display: undefined
         },
         class: {
-          'jv-ellipsis': true, 
+          'jv-ellipsis': true,
         },
         on: {
           click: this.toggle
@@ -109,7 +107,7 @@ export default {
     elements.push(h('span', {
       class: {
         'jv-item': true,
-        'jv-array': true, 
+        'jv-array': true,
       },
       domProps: {
         innerHTML: ']'

--- a/lib/types/json-object.vue
+++ b/lib/types/json-object.vue
@@ -53,7 +53,7 @@ export default {
       elements.push(h('span', {
         class: {
           'jv-toggle': true,
-          'open': !!this.expand, 
+          'open': !!this.expand,
         },
         on: {
           click: this.toggle
@@ -64,7 +64,7 @@ export default {
     elements.push(h('span', {
       class: {
         'jv-item': true,
-        'jv-object': true, 
+        'jv-object': true,
       },
       domProps: {
         innerHTML: '{'
@@ -90,13 +90,13 @@ export default {
       }
     }
 
-    if (!this.expand) {
+    if (!this.expand && Object.keys(this.jsonValue).length) {
       elements.push(h('span', {
         style: {
           display: this.expand ? 'none' : undefined
         },
         class: {
-          'jv-ellipsis': true, 
+          'jv-ellipsis': true,
         },
         on: {
           click: this.toggle
@@ -113,7 +113,7 @@ export default {
     elements.push(h('span', {
       class: {
         'jv-item': true,
-        'jv-object': true, 
+        'jv-object': true,
       },
       domProps: {
         innerHTML: '}'


### PR DESCRIPTION
Don't show ellipsis on empty objects and arrays;
Use forEach on arrays not to show functions added to prototype

Before:
<img width="338" alt="Screenshot 2019-05-31 at 15 16 16" src="https://user-images.githubusercontent.com/2388396/58708206-664bac80-83b7-11e9-9d78-56563c627232.png">

After:
<img width="326" alt="Screenshot 2019-05-31 at 15 15 10" src="https://user-images.githubusercontent.com/2388396/58708219-6fd51480-83b7-11e9-9d34-20cfb689f49a.png">
