### PR TITLE
Make dependencies peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "email": "sacha.stafyniak@gmail.com"
     }
   ],
-  "dependencies": {
+  "peerDependencies": {
     "clipboard": "^2.0.4",
     "vue": "^2.6.9"
   },


### PR DESCRIPTION
https://nodejs.org/es/blog/npm/peer-dependencies/

Peer dependencies were created specifically for plugins and it's better
to use them instead of just dependencies. A plugin package is meant
to be used with another "host" package, even though it does not always
directly use the host package.