### PR TITLE
fix: long string expand arrow display error

### DIFF
--- a/lib/types/json-string.vue
+++ b/lib/types/json-string.vue
@@ -11,7 +11,7 @@ export default {
   },
   data() {
     return {
-      expand: false,
+      expand: true,
       canExtend: false,
     }
   },
@@ -30,7 +30,7 @@ export default {
     const islink = REG_LINK.test(value)
     let domItem
 
-    if (this.expand) {
+    if (!this.expand) {
       domItem = {
         class: {
           'jv-ellipsis': true,


### PR DESCRIPTION
Fixed the problem that long string expand arrow was in opposite direction.

修复了长字符串收缩箭头反了的问题。