### PR TITLE
chore: move "vue" to "peerDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,7 @@
   "version": "2.2.19",
   "description": "vuejs展示json的组件",
   "main": "vue-json-viewer.js",
-  "files": [
-    "vue-json-viewer.js",
-    "ssr.js",
-    "style.css"
-  ],
+  "files": ["vue-json-viewer.js", "ssr.js", "style.css"],
   "directories": {
     "lib": "./lib",
     "example": "./example"
@@ -22,10 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/chenfengjw163/vue-json-viewer.git"
   },
-  "keywords": [
-    "vue",
-    "json"
-  ],
+  "keywords": ["vue", "json"],
   "homepage": "https://github.com/chenfengjw163/vue-json-viewer#readme",
   "author": {
     "name": "陈峰",
@@ -46,8 +39,7 @@
     }
   ],
   "dependencies": {
-    "clipboard": "^2.0.4",
-    "vue": "^2.6.9"
+    "clipboard": "^2.0.4"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.5",
@@ -73,6 +65,7 @@
     "style-loader": "^0.19.0",
     "uglifyjs-webpack-plugin": "^2.1.2",
     "url-loader": "^0.6.2",
+    "vue": "^2.6.9",
     "vue-loader": "^15.7.0",
     "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.6.9",
@@ -81,5 +74,8 @@
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",
     "webpack-merge": "^4.1.0"
+  },
+  "peerDependencies": {
+    "vue": "^2.6.9"
   }
 }


### PR DESCRIPTION
需要将 vue 这类 Dependencies 放到 peerDependencies 中

```
D:\Workstation\License\license\microapps\management-license>yarn run build
yarn run v1.22.5
$ qp build-microapp
D:\Workstation\License\license\microapps\management-license\node_modules\vue-template-compiler\index.js:10
  throw new Error(
  ^

Error:

Vue packages version mismatch:

- vue@2.6.14 (D:\Workstation\License\license\microapps\management-license\node_modules\vue\dist\vue.runtime.common.js)
- vue-template-compiler@2.6.12 (D:\Workstation\License\license\microapps\management-license\node_modules\vue-template-compiler\package.json)

This may cause things to work incorrectly. Make sure to use the same version for both.
If you are using vue-loader@>=10.0, simply update vue-template-compiler.
If you are using vue-loader@<10.0 or vueify, re-installing vue-loader/vueify should bump vue-template-compiler to the latest.

    at Object.<anonymous> (D:\Workstation\License\license\microapps\management-license\node_modules\vue-template-compiler\index.js:10:9)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (D:\Workstation\License\license\microapps\management-license\node_modules\@atsfe\qp-route-generator\lib\resolve.js:16:33)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

```
D:\Workstation\License\license\microapps\management-license>yarn why vue
yarn why v1.22.5
[1/4] Why do we have the module "vue"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "vue@2.6.14"
info Reasons this module exists
   - "vue-json-viewer" depends on it
   - Hoisted from "vue-json-viewer#vue"
info Disk size without dependencies: "3.36MB"
info Disk size with unique dependencies: "3.36MB"
info Disk size with transitive dependencies: "3.36MB"
info Number of shared dependencies: 0
Done in 1.22s.

D:\Workstation\License\license\microapps\management-license>yarn why vue-template-compiler
yarn why v1.22.5
[1/4] Why do we have the module "vue-template-compiler"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "vue-template-compiler@2.6.12"
info Reasons this module exists
   - "@atsfe#qp-cli" depends on it
   - Hoisted from "@atsfe#qp-cli#vue-template-compiler"
info Disk size without dependencies: "436KB"
info Disk size with unique dependencies: "584KB"
info Disk size with transitive dependencies: "584KB"
info Number of shared dependencies: 2
Done in 1.48s.
```